### PR TITLE
windows support

### DIFF
--- a/app/src/main/scala/conscript.scala
+++ b/app/src/main/scala/conscript.scala
@@ -1,32 +1,32 @@
 package conscript
 
 class Conscript extends xsbti.AppMain {
+  def run(config: xsbti.AppConfiguration) = Conscript.run(config.arguments)
+}
+
+object Conscript {
   import dispatch._
-  def run(config: xsbti.AppConfiguration) = {
-    val (cleanopt, repo) = config.arguments.partition(_ == "--clean-boot")
-    val result = cleanopt.headOption.filter { _ =>
-      Apply.bootdir.exists && Apply.bootdir.isDirectory
-    }.map { _ =>
-      Clean.clean(Apply.bootdir.listFiles).toLeft(
-        "Cleaned boot directory (%s)".format(Apply.bootdir)
-      )
-    }.getOrElse(Right("")).right.flatMap { in => (cleanopt, repo) match {
-      case (_, Array(GhProject(user, repo))) =>
-        Github.lookup(user, repo).right.flatMap {
-          case Nil => Left("No scripts found for %s/%s".format(user,repo))
-          case scripts =>
-            ((Right(in): Either[String, String]) /: scripts) { 
-              case (either, (name, launch)) =>
-                either.right.flatMap { cur =>
-                  Apply.config(user, repo, name, launch).right.map { 
-                    cur + "\n" +  _
-                  }
-                }
-            }
+
+  def main(args: Array[String]) { run(Array("--setup")) }
+
+  def run(args: Array[String]) = {
+    val (cleanopt, setupopt, repo) = args.partition(_ == "--clean-boot") match {
+      case (cleanopt, rest) =>
+        val (setupopt, repo) = rest.partition(_ == "--setup")
+        (cleanopt, setupopt, repo)
+    }
+
+    val result: Either[String, String] = (cleanopt.headOption, setupopt.headOption, repo) match {
+      case (Some(x), _, _) if Apply.bootdir.exists && Apply.bootdir.isDirectory =>
+        Clean.clean(Apply.bootdir.listFiles).toLeft("Cleaned boot directory (%s)".format(Apply.bootdir))
+      case (_, Some(x), _) =>
+        Apply.launchJar.right flatMap { _ =>
+          configure("n8han", "conscript")
         }
-      case (Array(opt, _*), Array()) => Right(in)
+      case (_, _, Array(GhProject(user, repo))) => configure(user, repo)
       case _ => Left(usage)
-    } }
+    }
+
     result fold ( { err =>
       println(err)
       Exit(1)
@@ -34,6 +34,19 @@ class Conscript extends xsbti.AppMain {
       println(msg)
       Exit(0)
     })
+  }
+
+  def configure(user: String, repo: String) = Github.lookup(user, repo).right.flatMap {
+    case Nil => Left("No scripts found for %s/%s".format(user,repo))
+    case scripts =>
+      ((Right(""): Either[String, String]) /: scripts) {
+        case (either, (name, launch)) =>
+          either.right.flatMap { cur =>
+            Apply.config(user, repo, name, launch).right.map {
+              cur + "\n" +  _
+            }
+          }
+      }
   }
   case class Exit(val code: Int) extends xsbti.Exit
   def usage = """Usage: cs [OPTION] [USER/PROJECT]"""

--- a/app/src/main/scala/github.scala
+++ b/app/src/main/scala/github.scala
@@ -5,7 +5,7 @@ import dispatch.liftjson.Js._
 import net.liftweb.json.JsonAST._
 import scala.util.control.Exception.allCatch
 
-object Github {
+object Github extends Launch {
   def lookup(user: String, repo: String) = {
     allCatch.opt { http(gh / "blob" / "all" / user / repo / "master" ># { js =>
       for {
@@ -20,11 +20,6 @@ object Github {
     }
   }
 
-  val http = new Http {
-    override def make_logger = new dispatch.Logger {
-      def info(msg: String, items: Any*) { }
-    }
-  }
   val gh = :/("github.com").secure / "api" / "v2" / "json"
   val Script = "^src/main/conscript/([^/]+)/launchconfig$".r
 }

--- a/app/src/main/scala/launch.scala
+++ b/app/src/main/scala/launch.scala
@@ -1,0 +1,58 @@
+package conscript
+
+import dispatch._
+import java.io.{FileOutputStream, File}
+import util.control.Exception._
+
+trait Launch {
+  val sbtversion = "0.7.7"
+  val sbtlaunchalias = "sbt-launch.jar"
+
+  def launchJar: Either[String, File] = configdir("sbt-launch-%s.jar" format sbtversion) match {
+    case jar if jar.exists => Right(jar)
+    case jar =>
+      try {
+        println("Fetching launcher...")
+        val launchalias = configdir(sbtlaunchalias)
+        if (!launchalias.getParentFile.exists) mkdir(launchalias)
+        else ()
+
+        val req = windows map { _ =>
+          // sbt-launch 0.7.7 has a bug: https://github.com/harrah/xsbt/pull/38
+          url("https://github.com/downloads/eed3si9n/xsbt/sbt-launch-0.7-SNAPSHOT.jar")
+        } getOrElse{url("https://simple-build-tool.googlecode.com/files/sbt-launch-%s.jar" format sbtversion)}
+
+        http(req >>> new FileOutputStream(jar))
+        windows map { _ =>
+          if (launchalias.exists) launchalias.delete
+          else ()
+
+          http(req >>> new FileOutputStream(launchalias))
+        } getOrElse {
+          val rt = Runtime.getRuntime
+          rt.exec("ln -sf %s %s" format (jar, launchalias)).waitFor
+        }
+        Right(jar)
+      } catch {
+        case e: Exception => Left("Error downloading sbt-launch-%s: %s" format (sbtversion, e.toString))
+      }
+  }
+
+  def / (a: String, b: String) = a + File.separatorChar + b
+  def forceslash(a: String) =
+    windows map { _ =>
+      "/" + (a replaceAll ("""\\""", """/"""))
+    } getOrElse {a}
+  def configdir(path: String) = homedir(/(".conscript", path))
+  def homedir(path: String) = new File(System.getProperty("user.home"), path)
+  def mkdir(file: File) =
+    catching(classOf[SecurityException]).either {
+      new File(file.getParent).mkdirs()
+    }.left.toOption.map { e => "Unable to create path " + file }
+  def windows =
+    System.getProperty("os.name") match {
+      case x: String if x contains "Windows" => Some(x)
+      case _ => None
+    }
+  val http = new Http with NoLogging
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,6 +1,6 @@
 project.organization=net.databinder
 project.name=conscript project
-sbt.version=0.7.4
-project.version=0.2.2
+sbt.version=0.7.7
+project.version=0.2.3-SNAPSHOT
 build.scala.versions=2.8.1
 project.initialize=false

--- a/project/build/project.scala
+++ b/project/build/project.scala
@@ -1,14 +1,15 @@
 import sbt._
 
 class Project(info: ProjectInfo) extends ParentProject(info) 
-    with posterous.Publish 
+    with posterous.Publish
     with conscript.Harness {
   lazy val app = project("app", 
                          "conscript", 
-                         new DefaultProject(_) with sxr.Publish {
+                         new DefaultProject(_) with sxr.Publish with assembly.AssemblyBuilder {
     val launch = "org.scala-tools.sbt" % "launcher-interface" % "0.7.4" % "provided"
-    val dj = "net.databinder" %% "dispatch-lift-json" % "0.8.0.Beta4"
-    val dn = "net.databinder" %% "dispatch-http" % "0.8.0.Beta4"
+    val dj = "net.databinder" %% "dispatch-lift-json" % "0.8.1"
+    val dn = "net.databinder" %% "dispatch-http" % "0.8.1"
+    override val assemblyJarName = "conscript-setup-%s.jar" format (version)
   })
   lazy val plugins = project("plugin", "conscript plugin", new PluginProject(_))
   override def postTitle(vers: String) = "conscript %s".format(vers)

--- a/project/plugins/plugins.scala
+++ b/project/plugins/plugins.scala
@@ -7,4 +7,6 @@ class Plugins(info: ProjectInfo) extends PluginDefinition(info) {
   // publish source to sourced.implicit.ly
   val sxr_publish = "net.databinder" % "sxr-publish" % "0.2.0"
   val conscript = "net.databinder" % "conscript-plugin" % "0.2.2"
+  val coda_repo = "Coda Hale's Repository" at "http://repo.codahale.com/"
+  val assembly = "com.codahale" % "assembly-sbt" % "0.1.1"
 }


### PR DESCRIPTION
`sbaz` is horrible because it contaminates the global classpath and it's version dependent on `scala`. If `conscript` provided Windows support, I can migrate away from `sbaz`.

I can't rely on `curl`, but I probably can assume `java`, so I just added `def main()` that downloads sbt-launch and installs `cs`. Running `$ sbt "project conscript" assembly` should produce `app/target/scala_2.8.1/conscript-setup-0.2.3-SNAPSHOT.jar`.

On any platform, running conscript-setup by double-clicking it or `java -jar`ing installs `cs`.
## sbt-launcher bug

There's a bug in sbt-launcher that fails to resolve absolute path within `launchconfig`. I made a fix and sent Mark a pull request, but in the meantime, conscript-setup now downloads `sbt-launch` from [eed3si9n/xsbt](https://github.com/downloads/eed3si9n/xsbt/sbt-launch-0.7-SNAPSHOT.jar).
