### PR TITLE
support versions

### DIFF
--- a/app/src/main/scala/conscript.scala
+++ b/app/src/main/scala/conscript.scala
@@ -11,8 +11,8 @@ class Conscript extends xsbti.AppMain {
         "Cleaned boot directory (%s)".format(Apply.bootdir)
       )
     }.getOrElse(Right("")).right.flatMap { in => (cleanopt, repo) match {
-      case (_, Array(GhProject(user, repo))) =>
-        Github.lookup(user, repo).right.flatMap {
+      case (_, Array(GhProject(user, repo, version))) =>
+        Github.lookup(user, repo, Option(version)).right.flatMap {
           case Nil => Left("No scripts found for %s/%s".format(user,repo))
           case scripts =>
             ((Right(in): Either[String, String]) /: scripts) { 
@@ -37,5 +37,5 @@ class Conscript extends xsbti.AppMain {
   }
   case class Exit(val code: Int) extends xsbti.Exit
   def usage = """Usage: cs [OPTION] [USER/PROJECT]"""
-  val GhProject = "([^/]+)/([^/]+)".r
+  val GhProject = "([^/]+)/([^/]+)(/[^/]+)?".r
 }

--- a/app/src/main/scala/github.scala
+++ b/app/src/main/scala/github.scala
@@ -4,20 +4,36 @@ import dispatch._
 import dispatch.liftjson.Js._
 import net.liftweb.json.JsonAST._
 import scala.util.control.Exception.allCatch
+import java.io.File
 
 object Github {
-  def lookup(user: String, repo: String) = {
+  def lookup(user: String, repo: String, version: Option[String]) = {
     allCatch.opt { http(gh / "blob" / "all" / user / repo / "master" ># { js =>
       for {
         blobs <- ('blobs ? obj)(js)
         JField(name, JString(sha)) <- blobs
         name <- Script.findFirstMatchIn(name)
       } yield {
-        (name.group(1), http(gh / "blob" / "show" / user / repo / sha as_str))
+        (name.group(1), http(gh / "blob" / "show" / user / repo / sha >- { str =>
+          version map { v => withversion(str, if (v startsWith "/") v drop 1 else v) } getOrElse {str}
+        }))
       }
     }) }.toRight {
       "Error finding for scripts for %s/%s".format(user,repo)
     }
+  }
+
+  def withversion(launchconfig: String, version: String) = {
+    var section: String = ""
+    (launchconfig.lines map { line =>
+      """\[\w+\]""".r.findFirstIn(line.trim) map { s =>
+        section = s
+      }
+      """version:.*""".r.findFirstIn(line.trim) match {
+        case Some(_) if section == "[app]" => "  version: " + version
+        case _ => line
+      }
+    }) mkString(System.getProperty("line.separator"))
   }
 
   val http = new Http {


### PR DESCRIPTION
Since we are grabbing jar files from the repos, I think overriding the version fits better than supporting branches. I added optional parsing so 

```
cs eed3si9n/scalaxb/0.5.5-SNAPSHOT
```

grabs the latest `launchconfig` but overrides `[app] version` value with `0.5.5-SNAPSHOT`.
