### PR TITLE
Private repository support for conscript

### DIFF
--- a/src/main/scala/credentials.scala
+++ b/src/main/scala/credentials.scala
@@ -1,0 +1,35 @@
+package conscript
+
+import java.util.Properties
+import java.io.{File, FileInputStream}
+
+import collection.JavaConversions._
+
+trait Credentials {
+  def withCredentials(req: dispatch.Request) =
+    credentials map { case (user, pass) => req as_! (user,pass) } getOrElse req
+
+  lazy val credentials: Option[(String,String)] = {
+    val props = readProps(new File(System.getProperty("user.home"), ".gh"))
+    val auth = for {
+      user <- props get "username"
+      pass <- (props get "token") orElse (props get "password")
+    } yield (user, pass)
+    auth.map {
+      case (user, pass) if props isDefinedAt "token" => (user + "/token", pass)
+      case creds => creds
+    }
+  }
+
+  val readProps: PartialFunction[File,Map[String,String]] = {
+    case file if file.exists =>
+      val p = new java.util.Properties
+      val fis = new FileInputStream(file)
+      p.load(fis)
+      fis.close
+      (Map.empty[String,String] /: p.propertyNames) { 
+        case (m, prop) => m + (prop.toString -> p.getProperty(prop.toString))
+      }
+    case _ => Map.empty[String,String]
+  }
+}

--- a/src/main/scala/github.scala
+++ b/src/main/scala/github.scala
@@ -6,7 +6,7 @@ import net.liftweb.json.JsonAST._
 import scala.util.control.Exception.allCatch
 import java.io.File
 
-object Github {
+object Github extends Credentials {
   import Conscript.http
 
   def lookup(user: String, repo: String, branch: String, version: Option[String]) = {
@@ -38,6 +38,6 @@ object Github {
     }) mkString(System.getProperty("line.separator"))
   }
 
-  val gh = :/("github.com").secure / "api" / "v2" / "json"
+  val gh = withCredentials(:/("github.com").secure / "api" / "v2" / "json")
   val Script = "^src/main/conscript/([^/]+)/launchconfig$".r
 }


### PR DESCRIPTION
Hello!
I've borrowed a bit of the credentials support from giter8 and applied it to conscript so it can be used with private repositories on Github.  Any chance of getting this incorporated into conscript?

Thanks,
- Aaron
