### PR TITLE
Add $CONSCRIPT_OPTS to the generated launcher.

### DIFF
--- a/src/main/scala/apply.scala
+++ b/src/main/scala/apply.scala
@@ -51,11 +51,11 @@ object Apply extends Launch {
   val javaopt = "-Xmx1G"
   def script(launchconfig: File) = windows map { _ =>
     """@echo off""" + "\r\n" +
-    ("""java %s -jar "%s" "@file://%s" %%*""" + "\r\n") format (javaopt, configdir(sbtlaunchalias),
+    ("""java %%CONSCRIPT_OPTS%% %s -jar "%s" "@file://%s" %%*""" + "\r\n") format (javaopt, configdir(sbtlaunchalias),
       forceslash(launchconfig.getCanonicalPath))
   } getOrElse {
     """#!/bin/sh
-      |java %s -jar %s @%s "$@"
+      |java $CONSCRIPT_OPTS %s -jar %s @%s "$@"
       |""" .stripMargin format (javaopt, configdir(sbtlaunchalias), launchconfig.getCanonicalPath)
   }
   val boot = """


### PR DESCRIPTION
Hi Nathan,

This change adds the CONSCRIPT_OPTS environment variable to the generated launcher (eg. for providing -Dhttp.proxyHost).
This will make conscript usable again at work (damn proxy).

Cheers
