### PR TITLE
modify launchconfig parsing regexp

### DIFF
--- a/src/main/scala/launchconfig.scala
+++ b/src/main/scala/launchconfig.scala
@@ -105,7 +105,7 @@ case class Launchconfig(configstring: String) {
     val values = mutable.Map[String, ArrayBuffer[String]]()
     
     for (line <- configstring.lines) {
-      """\[\w+\]""".r.findFirstIn(line.trim) map { s =>
+      """^\[\w+\]""".r.findFirstIn(line.trim) map { s =>
         sections += s
         values(s) = ArrayBuffer[String]()
       } getOrElse {


### PR DESCRIPTION
Hi Nathan,

This change fixes launchconfig parsing for xsbt 0.11.
regexp """[\w+]""" matches repository setting. for example https://github.com/harrah/xsbt/blob/0.11/src/main/conscript/sbt/launchconfig#L15

Thanks,
 Setsu
