### PR TITLE
add --no-exec option. it skips exec after installation 

### DIFF
--- a/src/main/scala/apply.scala
+++ b/src/main/scala/apply.scala
@@ -17,7 +17,7 @@ object Apply extends Launch {
     }.format(script))!
   }
 
-  def config(user: String, repo: String, name: String, launch: Launchconfig) = {
+  def config(user: String, repo: String, name: String, noexec: Boolean, launch: Launchconfig) = {
     val launchconfig = configdir(user / repo / name / "launchconfig")
 
     val place = scriptFile(name)
@@ -32,7 +32,7 @@ object Apply extends Launch {
       }
     }.toLeft {
       allCatch.opt {
-        exec(place.toString)
+        if (!noexec) exec(place.toString)
       } // ignore result status; the app might not have `--version`
       "Conscripted %s/%s to %s".format(user, repo, place)  
     }


### PR DESCRIPTION
Hi Nathan,

This changes adds --no-exec option.

conscript executes launchconfig after install. ( https://github.com/n8han/conscript/blob/master/src/main/scala/apply.scala#L35 )
installing xsbt, conscript launches screpl. screpl waits user inputs.

This changes allows to skip exec after installation.
I don't know this changes right fix or not...

Thanks,
 Setsu
