### PR TITLE
Stop on error to make it obvious when the setup fails

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo "
 Fetching current launch configuration...
 "


### PR DESCRIPTION
For example, if the user doesn't have write permission to ~/bin. This happened to me (I think I installed latex as root, maybe in a weird way - there are a bunch of latex scripts in my bin directory and bin was owned by root). I assume it printed out a permission denied message, but I didn't notice it, and at the end the setup.sh script printed "conscript installed to /home/donny/bin/cs".
