### PR TITLE
Install to ~/.bin instead

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -15,7 +15,7 @@ echo "
 [boot]
   directory: $CS/boot" >> $CLC
 
-BIN=$HOME/bin
+BIN=$HOME/.bin
 mkdir -p $BIN
 
 echo "#!/bin/sh


### PR DESCRIPTION
Installing to ~/bin generally causes a new directory to be made, which is visible. As this is a CLI program, it's not _needed_ to be shown in the users' home directory. Because of this, I feel a less visible and better place is ~/.bin.
