### PR TITLE
Use JAVA_OPTS for configuration

### DIFF
--- a/src/main/scala/apply.scala
+++ b/src/main/scala/apply.scala
@@ -51,11 +51,11 @@ object Apply extends Launch {
   val javaopt = "-Xmx1G"
   def script(launchconfig: File) = windows map { _ =>
     """@echo off""" + "\r\n" +
-    ("""java %%CONSCRIPT_OPTS%% %s -jar "%s" "@file://%s" %%*""" + "\r\n") format (javaopt, configdir(sbtlaunchalias),
+    ("""java %%JAVA_OPTS%% %%CONSCRIPT_OPTS%% %s -jar "%s" "@file://%s" %%*""" + "\r\n") format (javaopt, configdir(sbtlaunchalias),
       forceslash(launchconfig.getCanonicalPath))
   } getOrElse {
     """#!/bin/sh
-      |java $CONSCRIPT_OPTS %s -jar %s @%s "$@"
+      |java $JAVA_OPTS $CONSCRIPT_OPTS %s -jar %s @%s "$@"
       |""" .stripMargin format (javaopt, configdir(sbtlaunchalias), launchconfig.getCanonicalPath)
   }
 }


### PR DESCRIPTION
JAVA_OPTS is used for Java configuration. sbt uses it to set [proxies] (http://stackoverflow.com/questions/13803459/how-to-use-sbt-from-behind-proxy), among other settings.
In order to comply with sbt behaviour and reuse its proxy configuration we should pass JAVA_OPTS to the launch script.