### PR TITLE
adds environment variables CONSCRIPT_HOME and CONSCRIPT_BIN

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,17 +17,27 @@ you think. What?
 * Uses the same ivy cache as sbt itself
 
 So conscript just assumes a convention and helps you adhere to
-it. Firstly, `~/.conscript/boot` is used as a boot directory for
+it. First, you need to configure `$CONSCRIPT_HOME`
+(for example `$HOME/.conscript`).
+Then`$CONSCRIPT_HOME/boot` is used as a boot directory for
 all. Program launch configurations are stored according to the github
 project name and script name, such as:
 
-    ~/.conscript/foundweekends/conscript/cs/launchconfig
+    $CONSCRIPT_HOME/foundweekends/conscript/cs/launchconfig
 
-And finally, program scripts are created in `~/bin` that reference
-launch configurations, e.g. `~/bin/cs`
+And finally, program scripts are created in `$CONSCRIPT_HOME/bin` that
+reference launch configurations, e.g. `$CONSCRIPT_HOME/bin/cs`
 
 Installation
 ------------
+
+Put this in your start up shell script:
+
+```
+export CONSCRIPT_HOME="$HOME/.conscript"
+export CONSCRIPT_OPTS="-XX:MaxPermSize=512M -Dfile.encoding=UTF-8"
+export PATH=$CONSCRIPT_HOME/bin:$PATH
+```
 
 There are two methods of installation available.
 

--- a/README.markdown
+++ b/README.markdown
@@ -51,11 +51,6 @@ If you prefer, you can install conscript by piping this shell script.
 
     curl https://raw.githubusercontent.com/foundweekends/conscript/master/setup.sh | sh
 
-### Java 8
-
-If you're using a buggy preview release of Java, then Conscript will
-be buggy. Please use a release version of Java instead.
-    
 Use
 ---
 

--- a/notes/0.5.0.markdown
+++ b/notes/0.5.0.markdown
@@ -1,0 +1,28 @@
+  [76]: https://github.com/foundweekends/conscript/pull/76
+  [80]: https://github.com/foundweekends/conscript/pull/80
+  [@MrOutis]: https://github.com/MrOutis
+  [@andrelfpinto]: https://github.com/andrelfpinto
+  [@eed3si9n]: https://github.com/eed3si9n
+  [fw]: https://github.com/foundweekends/
+
+conscript (`cs`) is moved to [foundweekends][fw], an organization for people who like coding in the weekend.
+
+### CONSCRIPT_HOME changes
+
+Starting 0.5.0, scripts are created under `$CONSCRIPT_HOME/bin` instead of `$HOME/bin`. Please adjust your `PATH` accordingly.
+
+You can now use the environment variable `CONSCRIPT_HOME` to control where conscript downloads things (default: `$HOME/.conscript`).
+The directory where the scripts will be created can also be controlled via `CONSCRIPT_BIN` envonment variable. As noted above, the default value is `$CONSCRIPT_HOME/bin`.
+
+    export CONSCRIPT_HOME="$HOME/.conscript"
+    export CONSCRIPT_OPTS="-XX:MaxPermSize=512M -Dfile.encoding=UTF-8"
+    export PATH=$CONSCRIPT_HOME/bin:$PATH
+
+### other improvements
+
+- Includes `JAVA_OPTS` into the generated script. [#80][80] by [@andrelfpinto][@andrelfpinto]
+- Updates Scala, Dispatch, and scopt versions. [#85][85] by [@eed3si9n][@eed3si9n]
+
+### fixes
+
+- Uses sbt standalone launcher 1.0.0, instead of the sbt specific ones. [#76][76] by [@MrOutis][@MrOutis]

--- a/notes/0.5.0.markdown
+++ b/notes/0.5.0.markdown
@@ -1,5 +1,6 @@
   [76]: https://github.com/foundweekends/conscript/pull/76
   [80]: https://github.com/foundweekends/conscript/pull/80
+  [86]: https://github.com/foundweekends/conscript/pull/86
   [@MrOutis]: https://github.com/MrOutis
   [@andrelfpinto]: https://github.com/andrelfpinto
   [@eed3si9n]: https://github.com/eed3si9n
@@ -17,6 +18,8 @@ The directory where the scripts will be created can also be controlled via `CONS
     export CONSCRIPT_HOME="$HOME/.conscript"
     export CONSCRIPT_OPTS="-XX:MaxPermSize=512M -Dfile.encoding=UTF-8"
     export PATH=$CONSCRIPT_HOME/bin:$PATH
+
+[#86][86] by [@eed3si9n][@eed3si9n]
 
 ### other improvements
 

--- a/notes/about.markdown
+++ b/notes/about.markdown
@@ -1,3 +1,3 @@
 [conscript][cs] installs and updates Scala software.
 
-[cs]: https://github.com/n8han/conscript
+[cs]: https://github.com/foundweekends/conscript

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ CS_DEFAULT=$HOME/.conscript
 read -p "Enter configuration directory (default: $CS_DEFAULT): " CS
 CS="${CS:-$CS_DEFAULT}"
 
-BIN_DEFAULT=$HOME/bin
+BIN_DEFAULT=$HOME/.bin
 read -p "Enter installation directory (default: $BIN_DEFAULT): " BIN
 BIN="${BIN:-$BIN_DEFAULT}"
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,26 @@
 #!/bin/sh
 
-CS_DEFAULT=$HOME/.conscript
-read -p "Enter configuration directory (default: $CS_DEFAULT): " CS
-CS="${CS:-$CS_DEFAULT}"
-
-BIN_DEFAULT=$HOME/.bin
-read -p "Enter installation directory (default: $BIN_DEFAULT): " BIN
-BIN="${BIN:-$BIN_DEFAULT}"
+## To configure the installation of conscripted application,
+## set up the environment variable CONSCRIPT_HOME to something like $HOME/.conscript
+## This would the directory where launch JARs and launchconfigs will be donwloaded.
+##
+## By default, the scripts for the conscripted apps (g8, cs, etc.)
+## will be created under CONSCRIPT_HOME/bin.
+## This can also be configured using the environment variable CONSCRIPT_BIN.
+if [ -z "$CONSCRIPT_HOME" ]
+then
+  CS_DEFAULT=$HOME/.conscript
+  read -p "CONSCRIPT_HOME is not set. Is it ok to use $CS_DEFAULT? (Y/n): " YN
+  YN=${YN:-Yes}
+  case $YN in
+    [Yy]* ) break;;
+    * ) exit;;
+  esac
+  CS="${CS:-$CS_DEFAULT}"
+else
+  CS="$CONSCRIPT_HOME"
+fi
+BIN="${CONSCRIPT_BIN:-$CS/bin}"
 
 CSCS="$CS/foundweekends/conscript/cs"
 CLC="$CSCS/launchconfig"

--- a/src/main/scala/apply.scala
+++ b/src/main/scala/apply.scala
@@ -6,8 +6,8 @@ import java.io.File
 object Apply extends Launch {
 
   def scriptFile(name: String) = windows map { _ =>
-      homedir(("bin" / "%s.bat") format name)
-    } getOrElse { homedir("bin" / name) }
+      bindir / s"$name.bat"
+    } getOrElse { bindir / name }
 
   def exec(script: String) = {
     scala.sys.process.Process(windows.map { _ =>


### PR DESCRIPTION
### CONSCRIPT_HOME changes

Starting 0.5.0, scripts are created under `$CONSCRIPT_HOME/bin` instead of `$HOME/bin`. Please adjust your `PATH` accordingly.

You can now use the environment variable `CONSCRIPT_HOME` to control where conscript downloads things (default: `$HOME/.conscript`).
The directory where the scripts will be created can also be controlled via `CONSCRIPT_BIN` envonment variable. As noted above, the default value is `$CONSCRIPT_HOME/bin`.

    export CONSCRIPT_HOME="$HOME/.conscript"
    export CONSCRIPT_OPTS="-XX:MaxPermSize=512M -Dfile.encoding=UTF-8"
    export PATH=$CONSCRIPT_HOME/bin:$PATH