### PR TITLE
[Security] Move leading path change to trailing

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ bin_in_path=$(echo "$PATH" | grep -i "$BIN")
 
 if [ -z "$bin_in_path" ]
 then
-    echo 'PATH="'"$BIN"':$PATH"' >> $HOME/.bashrc
+    echo 'PATH="$PATH:'"$BIN"'"' >> $HOME/.bashrc
     exec bash
 fi
 


### PR DESCRIPTION
User-writable directories on the path can be dangerous, but they're *especially* dangerous when prioritized above system paths.  This practice allows applications to trivially compromise a system (e.g. by replacing `cd`, or more insidiously, replacing `sudo`).  This practice is avoided by always *appending* to the path, rather than prepending.