### PR TITLE
Fix proxy setting in setup.ps1

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -8,12 +8,16 @@ function GetOrElse($Value, $DefaultValue) {
 }
 
 function Get-ProxyAddress() {
-  $env:JAVA_OPTS -match ".*-Dhttp.proxyHost=(\S+).*" | Out-Null
-  $proxyHost = $matches[1]
-  $env:JAVA_OPTS -match ".*-Dhttp.proxyPort=([0-9]).*" | Out-Null
-  $proxyPort = $matches[1]
+  if ($env:JAVA_OPTS -match ".*-Dhttp\.proxyHost=(\S+).*") {
+    $proxyHost = $matches[1]
+  }
+  if ($env:JAVA_OPTS -match ".*-Dhttp\.proxyPort=([0-9]+).*") {
+    $proxyPort = $matches[1]
+  }
 
-  "http://${proxyHost}:${proxyPort}"
+  if ($proxyHost -And $proxyPort) {
+    "http://${proxyHost}:${proxyPort}"
+  }
 }
 
 # Helper object to download artifacts


### PR DESCRIPTION
- Fixed not to return proxy address when proxy setting does not exist
- Fix regex
  - Escape `.`
  - Fix proxyPort regex to `[0-9]+`