### PR TITLE
call shutdown method of dispatch singleton instance. add test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ env:
     secure: TSTItMYGCn50C5QqBXCvDZJ5HxmUqT1UZ2pwyVrZU/JzWn3zftSMtsVnjX6RVWSMGZIFC+b9u08aJFcDt03zQpMjD9WmglebO5RIufxc2Tbk6wBevVDYduKaNoTD2J2U6JOs1Ff8QP6q7vNdBfUBN7exaaF4MCw0GsanqriQIeA=
 
 script:
-- sbt test "project plugin" "^ scripted"
+- sbt publishLocal test "project plugin" "^ scripted"
+- java -jar ./target/scala-2.11/proguard/conscript-*.jar --version
 
 after_success:
 - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && sbt pushSiteIfChanged

--- a/src/main/scala/conscript.scala
+++ b/src/main/scala/conscript.scala
@@ -11,6 +11,19 @@ object Conscript {
     configBuilder.setFollowRedirects(true)
   }
 
+  private[this] def shutdownDispatch(): Unit = {
+    try {
+      dispatch.Http.shutdown()
+    } catch {
+      case NonFatal(e) => e.printStackTrace()
+    }
+    try {
+      http.shutdown()
+    } catch {
+      case NonFatal(e) => e.printStackTrace()
+    }
+  }
+
   case class Config(project: String = "",
                     branch: Option[String] = None,
                     clean_boot: Boolean = false,
@@ -106,11 +119,11 @@ object Conscript {
       case _ => Left(parser.usage)
     }.getOrElse { Left(parser.usage) }.fold( { err =>
       display.error(err)
-      http.shutdown
+      shutdownDispatch()
       1
     }, { msg =>
       display.info(msg)
-      http.shutdown
+      shutdownDispatch()
       0
     })
   }


### PR DESCRIPTION
dispatch 0.11.x/0.12.x has singleton instance in "object dispatch.Http"

https://github.com/dispatch/reboot/commit/46eed38f4bbf13f8809637d2b16d679355b70fba

I think we should call `dispatch.Http.shutdown` or `System.exit` bacause
for terminate the program immediately.